### PR TITLE
Transitivity speedup

### DIFF
--- a/map_counting/combinadic.jl
+++ b/map_counting/combinadic.jl
@@ -165,17 +165,15 @@ function permutation_next(n, v::Vector{Int})
         return(v)
 end
 
-function colex_bitstring(n,k)#,v::Vector{Int})
+function colex_bitstring(n::Int,k::Int)#,v::Vector{Int})
         if k==0
                 return([zeros(Int, n-k)])
         else
-                #if v == [ones(Int,k)..., zeros(Int, n-k)...]
-                        #return(v)
                 if k < n
                         l1 = [vcat([0], C) for C in colex_bitstring(n-1, k)]
                         
                 else
-                        l1 = []
+                        l1 = Vector{Int64}[]
                 end
                 l2 = [vcat([1], C) for C in colex_bitstring(n-1,k-1)]
                 l = vcat(l1, l2)

--- a/map_counting/e14_test.jl
+++ b/map_counting/e14_test.jl
@@ -1,0 +1,4 @@
+include("search_organization.jl")
+
+X = get_ghat_minseps(5,4)
+

--- a/map_counting/hypermap_search.jl
+++ b/map_counting/hypermap_search.jl
@@ -67,7 +67,7 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
                 #println("floop time = ")
                 #println(string(time()-flooptime))
         end     
-        return([Perm(Vector{Int}(sigma)), reduce(append!,outlist)])
+        return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
 end 
 
 function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vector{Vector{Int}}, n_phi_cycles::Int)
@@ -131,6 +131,6 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
 		    end
             #end
 		end
-		return([Perm(Vector{Int}(sigma)), reduce(append!,outlist)])
+		return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
 	end
 end

--- a/map_counting/hypermap_search.jl
+++ b/map_counting/hypermap_search.jl
@@ -67,7 +67,7 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
                 #println("floop time = ")
                 #println(string(time()-flooptime))
         end     
-        return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
+        return([Perm(Vector{Int}(sigma)), reduce(append!,outlist)])
 end 
 
 function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vector{Vector{Int}}, n_phi_cycles::Int)
@@ -131,6 +131,6 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
 		    end
             #end
 		end
-		return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
+		return([Perm(Vector{Int}(sigma)), reduce(append!,outlist)])
 	end
 end

--- a/map_counting/hypermap_search.jl
+++ b/map_counting/hypermap_search.jl
@@ -35,10 +35,7 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
 	H = centralizer(S,sigma)
 	HH = [Perm(Vector{Int}(x)) for x in H[1]]
         parts = [part for part in Combinatorics.partitions([Int(1):Int(n);],k)]
-	outlist = []
-	for i in 1:Threads.nthreads()
-		push!(outlist, [])
-	end
+	outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
         for part in parts
                 decomp = perm_components(part,Int(n))
                 #PP = perm_counter([length(x) for x in part])
@@ -80,11 +77,7 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
 		p_inv = Perm(Vector{Int}(sigma^(-1)))
 		H = centralizer(S,sigma)
 		HH = [Perm(Vector{Int}(x)) for x in H[1]]
-		outlist = []
-		for i in 1:Threads.nthreads()
-			push!(outlist, [])
-		end
-
+		outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
         cc= counter(part)
         blocklengths=[k*cc[k] for k in keys(cc)]
         K = [k for k in keys(cc)]
@@ -114,7 +107,12 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
                 N = N[filter(x -> block_parts[i][x] == 0, eachindex(block_parts[i]))]
             end
             theta_part = vcat(t_parts...)
+	    println(theta_part)
+	    println(typeof(theta_part))
+	    flush(stdout)
             decomp = deepcopy(perm_components(theta_part, n))
+	    println(decomp)
+	    flush(stdout)
             theta = make_perm(decomp[1],decomp[2], decomp[3], index)
             phi = theta^(-1)*p_inv
             if length(cycles(phi)) == n_phi_cycles

--- a/map_counting/hypermap_search.jl
+++ b/map_counting/hypermap_search.jl
@@ -35,10 +35,7 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
 	H = centralizer(S,sigma)
 	HH = [Perm(Vector{Int}(x)) for x in H[1]]
         parts = [part for part in Combinatorics.partitions([Int(1):Int(n);],k)]
-	outlist = []
-	for i in 1:Threads.nthreads()
-		push!(outlist, [])
-	end
+	outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
         for part in parts
                 decomp = perm_components(part,Int(n))
                 #PP = perm_counter([length(x) for x in part])
@@ -80,33 +77,21 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
 		p_inv = Perm(Vector{Int}(sigma^(-1)))
 		H = centralizer(S,sigma)
 		HH = [Perm(Vector{Int}(x)) for x in H[1]]
-		outlist = []
-		for i in 1:Threads.nthreads()
-			push!(outlist, [])
-		end
-
+		outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
         cc= counter(part)
         blocklengths=[k*cc[k] for k in keys(cc)]
         K = [k for k in keys(cc)]
         outer_structure = [colex_bitstring(n - sum(blocklengths[1:i-1]), blocklengths[i]) for i in 1:length(blocklengths)]
         PP = perm_counter(vcat([[k for i in 1:cc[k]] for k in keys(cc)]...))
         flooptime = time()
-		#tuple_prod= Iterators.product(outer_structure..., [makeRCI(k, cc[k]) for k in keys(cc)]..., PP...)
         tuple_prod = Iterators.product(outer_structure..., [1:makeRCI(k,cc[k]).Length for k in keys(cc)]..., PP...)
-        #tuple_prod = Iterators.product(outer_structure..., PP...)
         @floop for thetatuple in tuple_prod
         #for thetatuple in tuple_prod
-                #sleep(0.01)
             # thetatuple is a tuple with the first length(cc) being the big blocks and the remaining elements the "regular_combination_tuples"
             block_parts = deepcopy(thetatuple[1:length(keys(cc))])
-            #index = thetatuple[(1+length(keys(cc))):end]
             vindex = thetatuple[(length(keys(cc))+1):(end-length(part))]
             index = thetatuple[(1+end- length(part)):end]
-            #v_parts = deepcopy([x for x in thetatuple[(length(keys(cc))+1):(end-length(part))]])
             v_parts = [unrank_reg_combo(vindex[i], blocklengths[i], K[i]) for i in 1:length(vindex)]
-            #println(v_parts)
-            #flush(stdout)
-            #for v_parts in Iterators.product([makeRCI(k,cc[k]) for k in keys(cc)]...)
             N = [1:n;]
             t_parts = Vector{Vector{Int}}[]
             for i in 1:length(keys(cc))

--- a/map_counting/hypermap_search.jl
+++ b/map_counting/hypermap_search.jl
@@ -26,6 +26,11 @@ function make_perm(starters::Array{Int,1}, perm_parts::Array{Array{Int,1},1}, n:
         return(Perm(phi))
 end
 
+function make_cartesian(v::Vector{Int})
+       n = length(v) 
+       return(CartesianIndices(ntuple(i-> 1:v[i], n)))
+end
+
 function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}})
 	S = symmetric_group(n)
 	sigma = cperm(S, psitemp...)
@@ -37,10 +42,12 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
 	outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
         for part in parts
                 decomp = perm_components(part,Int(n))
-                PP = perm_counter([length(part[i]) for i in 1:length(part)])
+                #PP = perm_counter([length(part[i]) for i in 1:length(part)])
                 flooptime = time()
-                @floop for index in Iterators.product(PP...)
-			phi = make_perm(decomp[1],decomp[2], decomp[3], index)
+                #@floop for index in Iterators.product(PP...)
+                PP = make_cartesian([factorial(length(part[i])-1) for i in 1:length(part)])
+                Threads.@threads for index in PP
+			phi = make_perm(decomp[1],decomp[2], decomp[3], Tuple.(index))
 			theta = psi*phi
 			if length(cycles(theta)) == needed_verts
 				if 1 in [length(cyc) for cyc in cycles(theta)]
@@ -60,7 +67,7 @@ function get_phi_candidates_v2(n::Int,k::Int,g::Int, psitemp::Vector{Vector{Int}
 			end
                 end     
         end     
-        return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
+        return([[Perm(Vector{Int}(sigma)), x] for x in reduce(vcat,outlist)])
 end 
 
 function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vector{Vector{Int}}, n_phi_cycles::Int)
@@ -110,6 +117,67 @@ function get_phi_candidates_v1(n::Int, part::Vector{Int}, g::Int, psitemp::Vecto
 		        end
 		    end
 		end
-		return([Perm(Vector{Int}(sigma)), reduce(vcat,outlist)])
+		return([[Perm(Vector{Int}(sigma)), x] for x in reduce(vcat,outlist)])
 	end
 end
+
+function get_phi_candidates_thread(n::Int, part::Vector{Int}, g::Int, psitemp::Vector{Vector{Int}}, n_phi_cycles::Int)
+	if sum(part) != n
+		println("Invalid Partition")
+		return([])
+	else
+		S = symmetric_group(n)
+		sigma = cperm(S,psitemp...)
+		p_inv = Perm(Vector{Int}(sigma^(-1)))
+		H = centralizer(S,sigma)
+		HH = [Perm(Vector{Int}(x)) for x in H[1]]
+		outlist = [Perm{Int}[] for i in 1:Threads.nthreads()]
+        cc= counter(part)
+        blocklengths=[k*cc[k] for k in keys(cc)]
+        K = [k for k in keys(cc)]
+        outer_structure = [colex_bitstring(n - sum(blocklengths[1:i-1]), blocklengths[i]) for i in 1:length(blocklengths)]
+        PP = perm_counter(vcat([[k for i in 1:cc[k]] for k in keys(cc)]...))
+        looptime = time()
+        #tuple_prod = Iterators.product([1:makeRCI(k,cc[k]).Length for k in keys(cc)]..., PP...)
+        tuple_prod = Iterators.product(outer_structure..., PP...)
+        v_coord = make_cartesian([makeRCI(k,cc[k]).Length for k in keys(cc)])
+        #tuple_prod = Iterators.product(outer_structure..., [1:makeRCI(k,cc[k]).Length for k in keys(cc)]..., PP...)
+        #Threads.@threads for vindex in collect(Iterators.product([1:makeRCI(k,cc[k]).Length for k in keys(cc)]...))
+        Threads.@threads for vindex in v_coord
+        #@floop for thetatuple in tuple_prod
+            # thetatuple is a tuple with the first length(cc) being the big blocks and the remaining elements the "regular_combination_tuples"
+            #block_parts = deepcopy(thetatuple[1:length(keys(cc))])
+                v_parts = [unrank_reg_combo(vindex[i], blocklengths[i], K[i]) for i in 1:length(vindex)]
+            for thetatuple in tuple_prod
+                #vindex = thetatuple[1:(end-length(part))]
+                block_parts = deepcopy(thetatuple[1:length(keys(cc))])
+                index = thetatuple[(1+end- length(part)):end]
+                N = [1:n;]
+                t_parts = Vector{Vector{Int}}[]
+                for i in 1:length(keys(cc))
+                        push!(t_parts, [[N[filter(x-> block_parts[i][x] == 1, eachindex(N))][j] for j in w] for w in ct_to_p(v_parts[i])])
+                        N = N[filter(x -> block_parts[i][x] == 0, eachindex(block_parts[i]))]
+                end
+                theta_part = vcat(t_parts...)
+                decomp = deepcopy(perm_components(theta_part, n))
+                theta = make_perm(decomp[1],decomp[2], decomp[3], index)
+                phi = theta^(-1)*p_inv
+                if length(cycles(phi)) == n_phi_cycles
+                        is_min =1
+		                for g in HH
+		                        if (theta^g).d < theta.d
+		                                is_min=0
+		                                break
+		                        end
+		                end
+		                if is_min ==1
+		                        push!(outlist[Threads.threadid()], phi)
+		                end
+		        end
+		    end
+        end
+		return([[Perm(Vector{Int}(sigma)), x] for x in reduce(vcat,outlist)])
+	end
+end
+
+

--- a/map_counting/minseps.jl
+++ b/map_counting/minseps.jl
@@ -60,4 +60,4 @@ function main(max_g::Int)
 #    println(graphisotime)
 end
 
-main(5)
+main(4)

--- a/map_counting/minseps.jl
+++ b/map_counting/minseps.jl
@@ -60,4 +60,4 @@ function main(max_g::Int)
 #    println(graphisotime)
 end
 
-main(4)
+main(5)

--- a/map_counting/search_organization.jl
+++ b/map_counting/search_organization.jl
@@ -31,9 +31,6 @@ function get_class_candidates(g::Int, ghat::Int, E::Int, i::Int)
 	n_psi = sum([conj_class_size(part) for part in psi_candidates])
 	n_phi = sum([conj_class_size(part) for part in phi_candidates])
 	n_theta = sum([conj_class_size(part) for part in theta_candidates])
-	#Z = [length(psi_candidates)*n_phi, length(psi_candidates)*n_theta, length(phi_candidates)*n_psi, length(phi_candidates)*n_theta, length(theta_candidates)*n_psi, length(theta_candidates)*n_phi]
-	#println(string(Z))
-	#flush(stdout)
 	if n_psi*length(phi_candidates) >= n_phi*length(psi_candidates)
 		if n_phi > n_theta
 			theta_flag = 1
@@ -103,9 +100,6 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 				phi_cycles = conj_class_nums[4]
 				for psi_choice in psi_choices
 					psi = make_default_perm(psi_choice)
-					#println("psi = ")
-					#println(psi)
-					#flush(stdout)
 					outs = get_phi_candidates_v2(E, phi_cycles, ghat, psi)
 					push!(ghat_minseps_E, [[outs[1],phi] for phi in outs[2]])
 				end
@@ -117,17 +111,7 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 	else
 		return(ghat_minseps_E)
 	end
-	#Counter = 0
-	#for psi_choice in ghat_minseps_E
-	#	if length(psi_choice) == 2
-	#		Counter = Counter+length(psi_choice[2])
-	#	else
-	#		println("unexpected array length")
-	#		println(length(psi_choice))
-	#	end
-	#end
 	flush(stdout)
-	#return(ghat_minseps_E)
 end
 
 
@@ -139,79 +123,15 @@ function generate_minseps_genus(g::Int)
 		println(string(ghat))
 		flush(stdout)
 		glist = get_ghat_minseps(g,ghat)
-		#biggerlist = []
-		#for x in glist
-			#templist = [[x[1], i] for i in x[2]]
-            #println(string(length(templist)))
-            #flush(stdout)
-			#push!(biggerlist, templist)
-		#end
-		#gbiglist = reduce(append!,biggerlist)
-		#ghypermaps = [permpair for permpair in gbiglist if is_transitive_pair(permpair)]
 		push!(total_minseps, glist)
 	end
 	return(reduce(vcat,total_minseps))
 end
 
-## Returns the conjugacy class of a permutation as a list of cycle lengths
-#function conjclass(x::Perm{Int})
-#	return(sort([length(i) for i in cycles(x)]))
-#end
-#
-#function solve_conjugation(x::Perm{Int}, y::Perm{Int}, n)
-#           VV = reduce(vcat,sort([cycles(x)[i] for i in 1:length(cycles(x))], by=length))
-#           WW = reduce(vcat,sort([cycles(y)[i] for i in 1:length(cycles(x))], by=length))
-##           x_cyc_type = sort([length(cycles(x)[i]) for i in 1:length(cycles(x))])
-#           y_cyc_type = sort([length(cycles(y)[i]) for i in 1:length(cycles(y))])
-#           if x_cyc_type != y_cyc_type
-#               return(0)
-#           else
-#               tau = zeros(Int, n)
-#               for i in 1:n
-#                   tau[VV[i]] =WW[i]
-#               end
-#               t = Perm(tau)
-#               if t^-1 * x * t != y
-#                   println("OH NO!")
-#               end
-#               return(t)
-#           end
-#end
-
-# Takes a hypermap as input and determines if color-swapping is an isomorphism
-#function is_self_dual(x::Perm{Int}, y::Perm{Int})
-#	isdual = 0
-#	if conjclass(x) != conjclass(y)
-#		return(0)
-#	end
-#	E = sum(conjclass(x))
-#	t = solve_conjugation(x,y,E)
-#	S = symmetric_group(E)
-#	psi = perm(S, [x[i] for i in 1:E])
-#	phi = perm(S, [y[i] for i in 1:E])
-#	rho = perm(S, [t[i] for i in 1:E])
-#	H = centralizer(S, psi)[1]
-#	for h in H
-#		if (rho^(-1)*h^(-1)*phi*h*rho) == psi
-#			isdual = 1
-#			return(isdual)
-#		end
-#	end
-#	return(isdual)
-#end
-
 function count_embeds(hypermap_list::Vector{Vector{Perm{Int}}})
     tempcount = length(hypermap_list)
     for hypermap in hypermap_list
-	#if conjclass(hypermap[1]) != conjclass(hypermap[2])
-	#	tempcount = tempcount +1
-        #elseif is_self_color_dual(hypermap[1], hypermap[2]) == 1
-	#	tempcount = tempcount +1
 	if length(cycles(hypermap[1])) == length(cycles(hypermap[2]))
-		#if conjclass(hypermap[1]) != conjclass(hypermap[2])
-		#	println("was it double counted?")
-		#	println(hypermap)
-		#end
 		if is_self_color_dual(hypermap[1], hypermap[2]) == 0
 			tempcount= tempcount -0.5
 		end

--- a/map_counting/search_organization.jl
+++ b/map_counting/search_organization.jl
@@ -61,7 +61,7 @@ function make_default_perm(in_partition::Vector{Int})
 end
 
 function get_ghat_minseps(g::Int, ghat::Int)
-	big_ghat_minseps = []
+	big_ghat_minseps = Vector{Vector{Perm{Int}}}[]
 	for E in (g+ghat+1):(2*(g+ghat))
 		x = time()
 		push!(big_ghat_minseps, get_ghat_minseps_edges(g, ghat, E))
@@ -78,7 +78,7 @@ end
 # Find minimal separating ribbon graphs with ribbon graph genus ghat and e edges
 # Specialized version of get_ghat_minseps to be more easily split up for long calculations on multiple nodes
 function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
-	ghat_minseps_E = []
+	ghat_minseps_E = Vector{Perm{Int}}[]
 	needed_vertices = 2+g-ghat
 	for i in 1:div(needed_vertices,2)
 		conj_class_nums = get_class_candidates(g, ghat, E, i)
@@ -87,25 +87,24 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 			theta_choices = conj_class_nums[3]
 			for psi_choice in psi_choices
 				psi = make_default_perm(psi_choice)
-				tempouts = []
 				for theta_choice in theta_choices
-					push!(tempouts, get_phi_candidates_v1(E,theta_choice, ghat, psi, (conj_class_nums[4]))[2])
+					append!(ghat_minseps_E, [x for x in get_phi_candidates_thread(E,theta_choice, ghat, psi, (conj_class_nums[4]))])
 				end
-				outs = reduce(vcat,tempouts)
+				#outs = reduce(vcat,tempouts)
 				# Need to make psi into an actual Perm{Int} object now:
-				S = symmetric_group(E)
-				push!(ghat_minseps_E, [[Perm(Vector{Int}(cperm(S,psi...))), phi] for phi in outs])
+				#S = symmetric_group(E)
+				#append!(ghat_minseps_E, [x for x in outs])
 			end
 		else
 				phi_cycles = conj_class_nums[4]
 				for psi_choice in psi_choices
 					psi = make_default_perm(psi_choice)
 					outs = get_phi_candidates_v2(E, phi_cycles, ghat, psi)
-					push!(ghat_minseps_E, [[outs[1],phi] for phi in outs[2]])
+					append!(ghat_minseps_E, [x for x in outs])
 				end
 		end
 	end
-	ghat_minseps_E = reduce(vcat, ghat_minseps_E)
+	#ghat_minseps_E = reduce(vcat, ghat_minseps_E)
 	if g-ghat > 1
 		return([x for x in ghat_minseps_E if is_transitive_pair(x)])
 	else

--- a/map_counting/search_organization.jl
+++ b/map_counting/search_organization.jl
@@ -74,7 +74,7 @@ function get_ghat_minseps(g::Int, ghat::Int)
 		println(string(time()-x))
 		flush(stdout)
 	end
-	ghat_minseps = reduce(append!, big_ghat_minseps)
+	ghat_minseps = reduce(vcat, big_ghat_minseps)
 	return(ghat_minseps)
 end
 
@@ -94,7 +94,7 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 				for theta_choice in theta_choices
 					push!(tempouts, get_phi_candidates_v1(E,theta_choice, ghat, psi, (conj_class_nums[4]))[2])
 				end
-				outs = reduce(append!,tempouts)
+				outs = reduce(vcat,tempouts)
 				# Need to make psi into an actual Perm{Int} object now:
 				S = symmetric_group(E)
 				push!(ghat_minseps_E, [[Perm(Vector{Int}(cperm(S,psi...))), phi] for phi in outs])
@@ -111,7 +111,7 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 				end
 		end
 	end
-	ghat_minseps_E = reduce(append!, ghat_minseps_E)
+	ghat_minseps_E = reduce(vcat, ghat_minseps_E)
 	if g-ghat > 1
 		return([x for x in ghat_minseps_E if is_transitive_pair(x)])
 	else
@@ -150,7 +150,7 @@ function generate_minseps_genus(g::Int)
 		#ghypermaps = [permpair for permpair in gbiglist if is_transitive_pair(permpair)]
 		push!(total_minseps, glist)
 	end
-	return(reduce(append!,total_minseps))
+	return(reduce(vcat,total_minseps))
 end
 
 ## Returns the conjugacy class of a permutation as a list of cycle lengths
@@ -250,6 +250,6 @@ function minseps_list_to_graphs(minsep_list::Vector{Vector{Perm{Int}}}, g::Int)
         end
         # Need to deal with edge countness
         final_graphs = [getIsoClasses(sorted_graphs_list[e]) for e in 1:length(sorted_graphs_list)]
-        fgs = reduce(append!, final_graphs)
+        fgs = reduce(vcat, final_graphs)
         return(fgs)
 end

--- a/map_counting/search_organization.jl
+++ b/map_counting/search_organization.jl
@@ -74,7 +74,7 @@ function get_ghat_minseps(g::Int, ghat::Int)
 		println(string(time()-x))
 		flush(stdout)
 	end
-	ghat_minseps = reduce(vcat, big_ghat_minseps)
+	ghat_minseps = reduce(append!, big_ghat_minseps)
 	return(ghat_minseps)
 end
 
@@ -94,7 +94,7 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 				for theta_choice in theta_choices
 					push!(tempouts, get_phi_candidates_v1(E,theta_choice, ghat, psi, (conj_class_nums[4]))[2])
 				end
-				outs = reduce(vcat,tempouts)
+				outs = reduce(append!,tempouts)
 				# Need to make psi into an actual Perm{Int} object now:
 				S = symmetric_group(E)
 				push!(ghat_minseps_E, [[Perm(Vector{Int}(cperm(S,psi...))), phi] for phi in outs])
@@ -111,7 +111,7 @@ function get_ghat_minseps_edges(g::Int, ghat::Int, E::Int)
 				end
 		end
 	end
-	ghat_minseps_E = reduce(vcat, ghat_minseps_E)
+	ghat_minseps_E = reduce(append!, ghat_minseps_E)
 	if g-ghat > 1
 		return([x for x in ghat_minseps_E if is_transitive_pair(x)])
 	else
@@ -146,11 +146,11 @@ function generate_minseps_genus(g::Int)
             #flush(stdout)
 			#push!(biggerlist, templist)
 		#end
-		#gbiglist = reduce(vcat,biggerlist)
+		#gbiglist = reduce(append!,biggerlist)
 		#ghypermaps = [permpair for permpair in gbiglist if is_transitive_pair(permpair)]
 		push!(total_minseps, glist)
 	end
-	return(reduce(vcat,total_minseps))
+	return(reduce(append!,total_minseps))
 end
 
 ## Returns the conjugacy class of a permutation as a list of cycle lengths
@@ -250,6 +250,6 @@ function minseps_list_to_graphs(minsep_list::Vector{Vector{Perm{Int}}}, g::Int)
         end
         # Need to deal with edge countness
         final_graphs = [getIsoClasses(sorted_graphs_list[e]) for e in 1:length(sorted_graphs_list)]
-        fgs = reduce(vcat, final_graphs)
+        fgs = reduce(append!, final_graphs)
         return(fgs)
 end


### PR DESCRIPTION
Removed unnecessary transitivity tests when g-ghat =0,1.  Then started migrating away from using FLoops because too much computation time is being spent on dividing up the workload among threads, but that should be completed in a separate branch.